### PR TITLE
git-open: alter compare to allow you to compare current to base

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ git open [-help]
 
 `git open -compare=<branch-name>:<base-name>` will open the repo comparing the supplied branch against the base branch.
 
+`git open -compare=:<base-name>` will open the repo comparing your current
+branch against the base branch.
+
 `git open -compare=<branch-name>` will open the repo comparing the supplied branch against master.
 
 `git open -compare` will open the repo comparing the branch you are currently on against master.

--- a/git-open
+++ b/git-open
@@ -120,6 +120,9 @@ set_branch_compare_path() {
   branch=$(sed -e 's/\:.*//' <<< $1)
 
   if grep -E ':.*$' > /dev/null <<< $1; then
+    if [ -z "$branch" ]; then
+      branch=$(git rev-parse --abbrev-ref HEAD)
+    fi
     base=$(sed -e 's/^.*://' <<< $1)
     path=/compare/$base...$branch
   else


### PR DESCRIPTION
Made sense to allow the user to compare their branch to whatever base they want.