### PR TITLE
note: remove logic that deletes .git

### DIFF
--- a/git-open
+++ b/git-open
@@ -33,11 +33,6 @@ build_url() {
     url=$(sed -e 's_:_/_' -e 's_^git@_https://_' <<< $url)
   fi
 
-  # remove trailing '.git' from url
-  if grep -Ei '\.git[/]?$' > /dev/null <<< $url; then
-    url=$(sed -e 's_\.git.*$__' <<< $url)
-  fi
-
   url=$url$path
 }
 


### PR DESCRIPTION
This logic was originally just to make the urls tidier, but removing
anything from `.git` onwards in a url messes with git pages repos.