### PR TITLE
git-open: remove .git extension from repo if the path isn't empty

### DIFF
--- a/git-open
+++ b/git-open
@@ -33,6 +33,10 @@ build_url() {
     url=$(sed -e 's_:_/_' -e 's_^git@_https://_' <<< $url)
   fi
 
+  if [ -n "$path" ] && grep -Ei '\.git$' > /dev/null <<< $url; then
+    url=$(sed 's/\.git$//' <<< $url)
+  fi
+
   url=$url$path
 }
 


### PR DESCRIPTION
Github wasn't recognising a url if it the repo had the suffix `.git` as well as a path